### PR TITLE
Fix src path for nightshade-core precompile task

### DIFF
--- a/app/views/icons/_icons_list.html
+++ b/app/views/icons/_icons_list.html
@@ -1,4 +1,4 @@
-{% from 'src/icons/icons.macros.html' import icon %}
+{% from 'icons/icons.macros.html' import icon %}
 
 <ul class="icons-list grid">
   {% for icon_name in data %}


### PR DESCRIPTION
_NB Before merging this in I want to make sure the team is :ok: with the import path_
- We need to remove the src directory if we want to explicity declare it when we import files. Merging this PR fixes bug with precompile. In the rename, the `src` path got added to gulptask.
