### PR TITLE
Switch to loading Velocity via jspm

### DIFF
--- a/app/views/layout/_base_layout.html
+++ b/app/views/layout/_base_layout.html
@@ -38,7 +38,6 @@
       {% block body_content %}{% endblock %}
     </div>
 
-    <script src="//cdn.jsdelivr.net/velocity/1.2.3/velocity.min.js"></script>
     <script src="/jspm_packages/system.js"></script>
     <script src="/systemjs_config.js"></script>
     {% block scripts %}{% endblock %}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "rx": "npm:rx@^4.0.7",
       "rx-dom": "npm:rx-dom@^7.0.3",
       "then-request": "npm:then-request@^2.1.1",
+      "velocity-animate": "npm:velocity-animate@^1.2.3",
       "viljamis/feature.js": "github:viljamis/feature.js@^1.0.1",
       "waypoints": "npm:waypoints@^4.0.0"
     },

--- a/systemjs_config.js
+++ b/systemjs_config.js
@@ -28,6 +28,7 @@ System.config({
     "rx": "npm:rx@4.0.7",
     "rx-dom": "npm:rx-dom@7.0.3",
     "then-request": "npm:then-request@2.1.1",
+    "velocity-animate": "npm:velocity-animate@1.2.3",
     "viljamis/feature.js": "github:viljamis/feature.js@1.0.1",
     "waypoints": "npm:waypoints@4.0.0",
     "github:jspm/nodelibs-assert@0.1.0": {
@@ -773,6 +774,10 @@ System.config({
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:velocity-animate@1.2.3": {
+      "jquery": "npm:jquery@2.2.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:verror@1.3.6": {


### PR DESCRIPTION
We want to load Velocity via jspm instead of through the CDN to fix the linting errors that came up when fixing the linting errors in Accordion in https://github.com/CasperSleep/nightshade-core/pull/109
